### PR TITLE
Test remote media for srcset attribute

### DIFF
--- a/dude-load-media-from-remote.php
+++ b/dude-load-media-from-remote.php
@@ -19,7 +19,7 @@ namespace Dude_Load_Media_From_Remote;
 if ( getenv( 'WP_ENV' ) && ( 'staging' === getenv( 'WP_ENV') || 'development' === getenv( 'WP_ENV' ) ) && getenv( 'REMOTE_MEDIA_URL' ) ) {
   add_filter( 'wp_get_attachment_image_src', __NAMESPACE__ . '\maybe_load_media_from_remote', 999, 3 );
   add_filter( 'wp_prepare_attachment_for_js', __NAMESPACE__ . '\maybe_load_remote_media_file_for_js', 999, 2 );
-
+  add_filter( 'wp_calculate_image_srcset', __NAMESPACE__ . '\maybe_load_media_remote_for_srcset', 999, 5 );
 }
 
 /**
@@ -62,6 +62,48 @@ function maybe_load_media_from_remote( $image, $attachment_id ) {
     $image[0] = try_to_load_image_from_remote( $image[0] );
   }
   return $image;
+}
+
+/**
+ * Load remote file for srcset attributes.
+ *
+ * @param array  $sources {
+ *     One or more arrays of source data to include in the 'srcset'.
+ *
+ *     @type array $width {
+ *         @type string $url        The URL of an image source.
+ *         @type string $descriptor The descriptor type used in the image candidate string,
+ *                                  either 'w' or 'x'.
+ *         @type int    $value      The source width if paired with a 'w' descriptor, or a
+ *                                  pixel density value if paired with an 'x' descriptor.
+ *     }
+ * }
+ * @param array $size_array     {
+ *     An array of requested width and height values.
+ *
+ *     @type int $0 The width in pixels.
+ *     @type int $1 The height in pixels.
+ * }
+ * @param string $image_src     The 'src' of the image.
+ * @param array  $image_meta    The image meta data as returned by 'wp_get_attachment_metadata()'.
+ * @param int    $attachment_id Image attachment ID or 0.
+ * @return array The 'srcset' attribute value. False on error or when only one source exists.
+ */
+function maybe_load_media_remote_for_srcset( $sources, $size_array, $image_src, $image_meta, $attachment_id ) {
+  // Original attachment exists, assume that size variations exists as well
+  if ( attached_file_exists( $attachment_id ) ) {
+    return $sources;
+  }
+
+  if ( ! is_array( $sources ) ) {
+    return $sources;
+  }
+
+  foreach ( $sources as $key => $source ) {
+    $sources[ $key ] = try_to_load_image_from_remote($source['url']);
+  }
+
+  return $sources;
 }
 
 /**

--- a/dude-load-media-from-remote.php
+++ b/dude-load-media-from-remote.php
@@ -78,7 +78,7 @@ function maybe_load_media_from_remote( $image, $attachment_id ) {
  *                                  pixel density value if paired with an 'x' descriptor.
  *     }
  * }
- * @param array $size_array     {
+ * @param array  $size_array     {
  *     An array of requested width and height values.
  *
  *     @type int $0 The width in pixels.
@@ -100,11 +100,11 @@ function maybe_load_media_remote_for_srcset( $sources, $size_array, $image_src, 
   }
 
   foreach ( $sources as $key => $source ) {
-    $sources[ $key ] = try_to_load_image_from_remote($source['url']);
+    $sources[ $key ] = try_to_load_image_from_remote( $source['url'] );
   }
 
   return $sources;
-}
+} // end maybe_load_media_remote_for_srcset
 
 /**
  * Try to load image from remote


### PR DESCRIPTION
WordPress handles srcset attributes... in its own way. Default hooks for media URL's do not work for srcset. This PR hooks into `wp_calculate_image_srcset` and changes the media URL if remote is available.